### PR TITLE
added script as option for data api

### DIFF
--- a/src/arsors.cookie.js
+++ b/src/arsors.cookie.js
@@ -545,7 +545,7 @@ function arsorsCookie(customConfig) {
 }
 
 function arsorsCookieInitIFramesAndImages() {
-  var e = document.querySelectorAll('iframe,img');
+  var e = document.querySelectorAll('iframe,img,script');
     for (var i=0; i<e.length; i++) {
     if(e[i].getAttribute('data-src')) {
       e[i].setAttribute('src',e[i].getAttribute('data-src'));


### PR DESCRIPTION
I would like to use <script data-src="https://example"> - Can't use the config for it because it should only appear on a specific page.